### PR TITLE
Fixing issues with creating invalid keys

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -140,10 +140,10 @@ if ($InitEnv) {
     Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
 
     # TELERIK_ENCRYPTION_KEY = random 64-128 chars
-    Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128)
+    Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
 
     # MEDIA_REQUEST_PROTECTION_SHARED_SECRET
-    Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64)
+    Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
 
     # SQL_SA_PASSWORD
     # Need to ensure it meets SQL complexity requirements


### PR DESCRIPTION
Keys are sometimes not accepted for TELERIK_ENCRYPTION_KEY and/or MEDIA_REQUEST_PROTECTION_SHARED_SECRET.

**Error example:**
Building containers...
Invalid template: "gcK+~o9`CeGJ2lA/ckk@k;9x}($"
C:\p\xmcloud-sxa\up.ps1 : Container build failed, see errors above.

See also [Serge van der Oevers blog post](https://www.sergevandenoever.nl/XM_Cloud_SxaStarter/) under chapter **Spinning up the containers**.